### PR TITLE
added environments and infobar in tereni

### DIFF
--- a/frontend/rekreacija/angular.json
+++ b/frontend/rekreacija/angular.json
@@ -59,7 +59,13 @@
               "optimization": false,
               "extractLicenses": false,
               "sourceMap": true,
-              "namedChunks": true
+              "namedChunks": true,
+              "fileReplacements": [
+                {
+                  "replace": "src/app/environments/environment.ts",
+                  "with": "src/app/environments/environment.development.ts"
+                }
+              ]
             }
           },
           "defaultConfiguration": "production"

--- a/frontend/rekreacija/src/app/app.module.ts
+++ b/frontend/rekreacija/src/app/app.module.ts
@@ -13,6 +13,7 @@ import { HTTP_INTERCEPTORS, provideHttpClient, withInterceptors, withInterceptor
 import { authInterceptor} from "./interceptors/auth.interceptor";
 import { ObavjestenjaComponent } from './components/pages/obavjestenja/obavjestenja.component';
 import {AuthModalComponent} from "./modals/auth-modal/auth-modal.component";
+import { TerenComponent } from './components/pages/teren/teren.component';
 
 @NgModule({
   declarations: [
@@ -21,7 +22,8 @@ import {AuthModalComponent} from "./modals/auth-modal/auth-modal.component";
         FooterComponent,
         LoginComponent,
         RegisterComponent,
-        ObavjestenjaComponent
+        ObavjestenjaComponent,
+        TerenComponent
     ],
 
   bootstrap: [AppComponent],

--- a/frontend/rekreacija/src/app/components/pages/teren/teren.component.html
+++ b/frontend/rekreacija/src/app/components/pages/teren/teren.component.html
@@ -1,1 +1,9 @@
 <div id="map" style="width: 100%; height: 500px;"></div>
+
+<div class="info-sidebar" [class.open]="selectedBalon" *ngIf="openInfo">
+    <button class="close-btn" (click)="closeSidebar()">×</button>
+    <h2>{{ selectedBalon?.name }}</h2>
+    <img [src]="selectedBalon?.imageUrl" alt="{{ selectedBalon?.name }}" />
+    <p>Ovo su dodatne informacije o balonu…</p>
+    <a [href]="selectedBalon?.linkUrl2" target="_blank">{{ selectedBalon?.linkText2 }}</a>
+  </div>

--- a/frontend/rekreacija/src/app/components/pages/teren/teren.component.scss
+++ b/frontend/rekreacija/src/app/components/pages/teren/teren.component.scss
@@ -1,0 +1,40 @@
+.map-container {
+    width: 100%;
+    height: 100vh;
+}
+
+.info-sidebar {
+    position: absolute;
+    top: 0;
+    margin-top: 72px;
+    right: -320px;
+    width: 320px;
+    height: 500px;
+    background: white;
+    box-shadow: -2px 0 8px rgba(0,0,0,0.2);
+    padding: 1rem;
+    transition: right 0.3s ease;
+    overflow-y: auto;
+    z-index: 1000;
+
+    &.open {
+        right: 0;
+    }
+
+    .close-btn {
+        background: none;
+        border: none;
+        font-size: 1.5rem;
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        cursor: pointer;
+    }
+
+    img {
+        width: 100%;
+        height: auto;
+        margin-bottom: 1rem;
+    }
+}
+

--- a/frontend/rekreacija/src/app/components/pages/teren/teren.component.ts
+++ b/frontend/rekreacija/src/app/components/pages/teren/teren.component.ts
@@ -13,6 +13,15 @@ const customIcon = L.icon({
   // shadowAnchor: [12, 41]
 });
 
+interface Balon {
+  name: string;
+  coordinatesX: number;
+  coordinatesY: number;
+  imageUrl: string;
+  linkUrl2: string;
+  linkText2: string;
+}
+
 @Component({
   selector: 'app-teren',
   templateUrl: './teren.component.html',
@@ -22,8 +31,69 @@ const customIcon = L.icon({
 export class TerenComponent implements OnInit, AfterViewInit {
   private map: L.Map | undefined;
   private centroid: L.LatLngExpression = [42.4304, 19.2594]; // Koordinate Podgorice (primer)
+  public selectedBalon: Balon | null = null;
+  public openInfo: Boolean = false;
 
   constructor() { }
+
+  private baloni: Balon[] = [
+    {
+      name: 'Balon Gimnazije',
+      coordinatesX: 42.447688,
+      coordinatesY: 19.264295,
+      imageUrl: 'assets/gimnazija.jpg',
+      linkUrl2: "http://localhost:4200",
+      linkText2: 'Zakazi termin'
+    },
+    {
+      name: 'Stampar Sports Centre',
+      coordinatesX: 42.446253,
+      coordinatesY: 19.242308,
+      imageUrl: 'assets/stampar.jpg',
+      linkUrl2: "http://localhost:4200",
+      linkText2: 'Zakazi termin'
+    },
+    {
+      name: 'Balon za mali fudbal Bernabeu',
+      coordinatesX: 42.425285,
+      coordinatesY: 19.232699,
+      imageUrl: 'assets/bernabeu.jpg',
+      linkUrl2: "http://localhost:4200",
+      linkText2: 'Zakazi termin'
+    },
+    {
+      name: 'Balon Tolosi',
+      coordinatesX: 42.453766,
+      coordinatesY: 19.215700,
+      imageUrl: 'assets/tolosi.jpg',
+      linkUrl2: "http://localhost:4200",
+      linkText2: 'Zakazi termin'
+    },
+    {
+      name: 'Sportski Centar Dadex',
+      coordinatesX: 42.443522,
+      coordinatesY: 19.281300,
+      imageUrl: 'assets/dadex.jpg',
+      linkUrl2: "http://localhost:4200",
+      linkText2: 'Zakazi termin'
+    },
+    {
+      name: 'Arena Sportski Centar',
+      coordinatesX: 42.431683,
+      coordinatesY: 19.257928,
+      imageUrl: 'assets/arena.jpeg',
+      linkUrl2: "http://localhost:4200",
+      linkText2: 'Zakazi termin'
+    },
+    {
+      name: 'Balon za mali fudbal Sutjeska',
+      coordinatesX: 42.447610,
+      coordinatesY: 19.256017,
+      imageUrl: 'assets/sutjeska.jpg',
+      linkUrl2: "http://localhost:4200",
+      linkText2: 'Zakazi termin'
+    }
+  ]
 
   ngOnInit(): void {
   }
@@ -45,93 +115,38 @@ export class TerenComponent implements OnInit, AfterViewInit {
     });
     tiles.addTo(this.map);
 
-    // const sutjeska = L.marker([42.447610, 19.256017]).addTo(this.map);
+    
 
-    const baloni = [
-      {
-        name: 'Balon Gimnazije',
-        coordinatesX: 42.447688,
-        coordinatesY: 19.264295,
-        imageUrl: 'assets/gimnazija.jpg',
-        linkUrl1: 'http://localhost:4200',
-        linkText1: 'Vise o balonu',
-        linkUrl2: 'http://localhost:4200',
-        linkText2: 'Zakazi termin'
-      },
-      {
-        name: 'Stampar Sports Centre',
-        coordinatesX: 42.446253,
-        coordinatesY: 19.242308,
-        imageUrl: 'assets/stampar.jpg',
-        linkUrl1: 'http://localhost:4200',
-        linkText1: 'Vise o balonu',
-        linkUrl2: 'http://localhost:4200',
-        linkText2: 'Zakazi termin'
-      },
-      {
-        name: 'Balon za mali fudbal Bernabeu',
-        coordinatesX: 42.425285,
-        coordinatesY: 19.232699,
-        imageUrl: 'assets/bernabeu.jpg',
-        linkUrl1: 'http://localhost:4200',
-        linkText1: 'Vise o balonu',
-        linkUrl2: 'http://localhost:4200',
-        linkText2: 'Zakazi termin'
-      },
-      {
-        name: 'Balon Tolosi',
-        coordinatesX: 42.453766,
-        coordinatesY: 19.215700,
-        imageUrl: 'assets/tolosi.jpg',
-        linkUrl1: 'http://localhost:4200',
-        linkText1: 'Vise o balonu',
-        linkUrl2: 'http://localhost:4200',
-        linkText2: 'Zakazi termin'
-      },
-      {
-        name: 'Sportski Centar Dadex',
-        coordinatesX: 42.443522,
-        coordinatesY: 19.281300,
-        imageUrl: 'assets/dadex.jpg',
-        linkUrl1: 'http://localhost:4200',
-        linkText1: 'Vise o balonu',
-        linkUrl2: 'http://localhost:4200',
-        linkText2: 'Zakazi termin'
-      },
-      {
-        name: 'Arena Sportski Centar',
-        coordinatesX: 42.431683,
-        coordinatesY: 19.257928,
-        imageUrl: 'assets/arena.jpeg',
-        linkUrl1: 'http://localhost:4200',
-        linkText1: 'Vise o balonu',
-        linkUrl2: 'http://localhost:4200',
-        linkText2: 'Zakazi termin'
-      },
-      {
-        name: 'Balon za mali fudbal Sutjeska',
-        coordinatesX: 42.447610,
-        coordinatesY: 19.256017,
-        imageUrl: 'assets/sutjeska.jpg',
-        linkUrl1: 'http://localhost:4200',
-        linkText1: 'Vise o balonu',
-        linkUrl2: 'http://localhost:4200',
-        linkText2: 'Zakazi termin'
-      }
-    ]
-
-    baloni.forEach(place => {
+    this.baloni.forEach(place => {
       const popupContent = `
         <b>${place.name}</b><br>
         <img src="${place.imageUrl}" alt="${place.name}" style="width:200px;max-width:200px;"><br>
-        <a href="${place.linkUrl1}" target="_blank">${place.linkText1}</a>
+        <a href="/teren" class="info-link">Vise o balonu</a>
         <span style="float: right;"><a href="${place.linkUrl2}" target="_blank">${place.linkText2}</a></span>
       `;
-      L.marker([place.coordinatesX,place.coordinatesY])
+      const marker = L.marker([place.coordinatesX,place.coordinatesY])
         .bindPopup(popupContent)
         .addTo(this.map!);
+      
+        marker.on('popupopen', () => {
+          const link: HTMLElement | null = document.querySelector('.info-link');
+          if (link) {
+            link.addEventListener('click', (e) => {
+              e.preventDefault();
+              this.openInfo = !this.openInfo
+              this.showSidebar(place);
+            });
+          }
+        });
     })
   }
 
+  public showSidebar(balon: Balon) {
+    this.selectedBalon = balon;
+  }
+
+  public closeSidebar() {
+    this.selectedBalon = null;
+  }
 
 }

--- a/frontend/rekreacija/src/app/environments/environment.development.ts
+++ b/frontend/rekreacija/src/app/environments/environment.development.ts
@@ -1,0 +1,3 @@
+export const environment = {
+    API_URL: "http://localhost:8080"
+};

--- a/frontend/rekreacija/src/app/environments/environment.ts
+++ b/frontend/rekreacija/src/app/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+    API_URL: "http://localhost:8080"
+};

--- a/frontend/rekreacija/src/app/modals/auth-modal/auth-modal.component.html
+++ b/frontend/rekreacija/src/app/modals/auth-modal/auth-modal.component.html
@@ -9,7 +9,7 @@
         <p>Morate biti ulogovani kako biste pristupili stranici.</p>
       </div>
       <div class="modal-footer flex-column align-items-stretch w-100 gap-2 pb-3 border-top-0">
-        <button type="button" class="btn btn-lg btn-primary" (click)="onConfirm()">OK</button>
+        <button type="button" class="btn btn-lg btn-primary" (click)="onConfirm()">Uloguj se</button>
         <button type="button" class="btn btn-lg btn-secondary" data-bs-dismiss="modal" (click)="onCancel()">Otkaži</button>
       </div>
     </div>

--- a/frontend/rekreacija/src/app/services/login.service.ts
+++ b/frontend/rekreacija/src/app/services/login.service.ts
@@ -1,13 +1,15 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from "@angular/common/http";
+import { environment } from '../environments/environment.development';
 
 @Injectable({
   providedIn: 'root'
 })
 export class LoginService {
+  private apiUrl = `${environment.API_URL}/login`
 
   constructor( private http: HttpClient ) { }
   userLogin(user:any){
-    return this.http.post("http://localhost:8080/login", user, { responseType: 'text' });
+    return this.http.post(this.apiUrl, user, { responseType: 'text' });
   }
 }

--- a/frontend/rekreacija/src/app/services/obavjestenja.service.ts
+++ b/frontend/rekreacija/src/app/services/obavjestenja.service.ts
@@ -1,9 +1,11 @@
 import { Injectable } from '@angular/core';
+import { environment } from '../environments/environment.development';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ObavjestenjaService {
+  private apiUrl = `${environment.API_URL}/api/obavjestenje`
 
   constructor() { }
 }

--- a/frontend/rekreacija/src/app/services/register.service.ts
+++ b/frontend/rekreacija/src/app/services/register.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from "@angular/common/http";
+import { environment } from '../environments/environment.development';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RegisterService {
-    private apiUrl = 'http://localhost:8080/register';
+    private apiUrl = `${environment.API_URL}/register`;
 
   constructor( private http: HttpClient ) { }
   userRegister(user:any){

--- a/frontend/rekreacija/src/app/services/teren.service.ts
+++ b/frontend/rekreacija/src/app/services/teren.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
+import { environment } from '../environments/environment.development';
 
 @Injectable({
   providedIn: 'root'
 })
 export class TerenService {
-  private apiUrl = 'http://localhost:8080/teren';
+  private apiUrl = `${environment.API_URL}/api/teren`;
 
   constructor() { }
 }


### PR DESCRIPTION
Koristi se ${environment.API_URL} umjesto http://localhost:8080 u servisima, i na klik linka "vise o balonu" se otvara sidebar sa prosirenim informacijama